### PR TITLE
Update to work with python3 and geohash2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ It is implemented in Cython.
 
 ## Dependencies
 
-**trajectory_distance** is tested to work under Python 2.7 and the following dependencies :
+**trajectory_distance** is tested to work under Python 3.6 and the following dependencies:
  
-* NumPy >= 1.14.0
-* Cython >= 0.27.3
-* shapely >= 1.6.4
-* Geohash ==1.0
-* pandas >= 0.20.3
-* scipy >=0.19.1
+* NumPy >= 1.16.2
+* Cython >= 0.29.6
+* shapely >= 1.6.4.post2
+* geohash2 == 1.1
+* pandas >= 0.24.2
+* scipy >= 0.20.3
 * A working C/C++ compiler.
 
 ## Install

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     cmdclass={'build_ext': build_ext},
     ext_modules=ext_modules,
     include_dirs=[numpy.get_include()],
-    install_requires=["numpy>=1.14.0", "Cython>=0.27.3", "Shapely>=1.6.4", "Geohash==1.0", 'pandas>=0.20.3',
+    install_requires=["numpy>=1.14.0", "Cython>=0.27.3", "Shapely>=1.6.4", "geohash2==1.1", 'pandas>=0.20.3',
                       'scipy>=0.19.1'],
     description="Distance to compare 2D-trajectories in Cython",
     packages=["traj_dist", "traj_dist.cydist", "traj_dist.pydist"],

--- a/traj_dist/benchmark.py
+++ b/traj_dist/benchmark.py
@@ -23,7 +23,7 @@ for distance in ["sspd", "frechet", "discret_frechet", "hausdorff", "dtw", "lcss
 t_cells_conversion_dic = collections.defaultdict(int)
 for precision in [5, 6, 7]:
     cells_list_, _, _, _, _ = trajectory_set_grid(traj_list, precision=precision)
-    cells_list = map(lambda x: np.array(x)[:, :2], cells_list_)
+    cells_list = [np.array(x)[:, :2] for x in cells_list_]
 
     t_cells_conversion = timeit.timeit(lambda: trajectory_set_grid(traj_list, precision=7), number=1)
     t_cells_conversion_dic[precision] = t_cells_conversion

--- a/traj_dist/distance.py
+++ b/traj_dist/distance.py
@@ -1,14 +1,14 @@
-from pydist.linecell import trajectory_set_grid
+from .pydist.linecell import trajectory_set_grid
 
-from cydist.sspd import c_e_sspd, c_g_sspd
-from cydist.dtw import c_e_dtw, c_g_dtw
-from cydist.erp import c_e_erp, c_g_erp
-from cydist.edr import c_e_edr, c_g_edr
-from cydist.lcss import c_e_lcss, c_g_lcss
-from cydist.hausdorff import c_e_hausdorff, c_g_hausdorff
-from cydist.discret_frechet import c_discret_frechet
-from cydist.frechet import c_frechet
-from cydist.sowd import c_sowd_grid
+from .cydist.sspd import c_e_sspd, c_g_sspd
+from .cydist.dtw import c_e_dtw, c_g_dtw
+from .cydist.erp import c_e_erp, c_g_erp
+from .cydist.edr import c_e_edr, c_g_edr
+from .cydist.lcss import c_e_lcss, c_g_lcss
+from .cydist.hausdorff import c_e_hausdorff, c_g_hausdorff
+from .cydist.discret_frechet import c_discret_frechet
+from .cydist.frechet import c_frechet
+from .cydist.sowd import c_sowd_grid
 
 import numpy as np
 
@@ -495,7 +495,7 @@ def pdist(traj_list, metric="sspd", type_d="euclidean", converted=None, precisio
     M : a nT x nT numpy array. Where the i,j entry is the distance between traj_list[i] and traj_list[j]
     """
 
-    list_dim = map(lambda x: x.shape[1] if len(x.shape) > 1 else 1, traj_list)
+    list_dim = [x.shape[1] if len(x.shape) > 1 else 1 for x in traj_list]
     nb_traj = len(traj_list)
     if not (len(set(list_dim)) == 1):
         raise ValueError("All trajectories must have same dimesion !")
@@ -517,7 +517,7 @@ def pdist(traj_list, metric="sspd", type_d="euclidean", converted=None, precisio
             raise ValueError("Euclidean implementation for distance " +
                              metric + " is not disponible if your data is not already converted in cell format")
 
-    print("Computing " + type_d + " distance " + metric + " for %d trajectories" % nb_traj)
+    print(("Computing " + type_d + " distance " + metric + " for %d trajectories" % nb_traj))
     M = np.zeros(sum(range(nb_traj)))
     dist = METRIC_DIC[type_d][metric]
     if metric.startswith("sowd_grid"):
@@ -534,7 +534,7 @@ def pdist(traj_list, metric="sspd", type_d="euclidean", converted=None, precisio
                 precision = 7
             print("Cells conversion start")
             cells_list_, _, _, _, _ = trajectory_set_grid(traj_list, precision)
-            cells_list = map(lambda x: np.array(x)[:, :2], cells_list_)
+            cells_list = [np.array(x)[:, :2] for x in cells_list_]
             print("Cells conversion ok")
         im = 0
         for i in range(nb_traj):
@@ -666,9 +666,9 @@ def cdist(traj_list_1, traj_list_2, metric="sspd", type_d="euclidean", converted
 
     """
 
-    list_dim_1 = map(lambda x: x.shape[1], traj_list_1)
+    list_dim_1 = [x.shape[1] for x in traj_list_1]
     nb_traj_1 = len(traj_list_1)
-    list_dim_2 = map(lambda x: x.shape[1], traj_list_2)
+    list_dim_2 = [x.shape[1] for x in traj_list_2]
     nb_traj_2 = len(traj_list_2)
     if not (len(set(list_dim_1 + list_dim_2)) == 1):
         raise ValueError("All trajectories must have same dimesion !")
@@ -682,7 +682,7 @@ def cdist(traj_list_1, traj_list_2, metric="sspd", type_d="euclidean", converted
     if not (type_d in ["spherical", "euclidean"]):
         raise ValueError("The type_d argument should be 'euclidean' or 'spherical'\ntype_d given is : " + type_d)
 
-    print("Computing " + type_d + " distance " + metric + " for %d and %d trajectories" % (nb_traj_1, nb_traj_2))
+    print(("Computing " + type_d + " distance " + metric + " for %d and %d trajectories" % (nb_traj_1, nb_traj_2)))
     M = np.zeros((nb_traj_1, nb_traj_2))
     dist = METRIC_DIC[type_d][metric]
     if metric.startswith("sowd_grid"):
@@ -699,8 +699,8 @@ def cdist(traj_list_1, traj_list_2, metric="sspd", type_d="euclidean", converted
                               "is False. Default is 7")
                 precision = 7
             cells_list, _, _, _, _ = trajectory_set_grid(traj_list_1 + traj_list_2, precision)
-            cells_list_1 = map(lambda x: np.array(x)[:, :2], cells_list[:nb_traj_1])
-            cells_list_2 = map(lambda x: np.array(x)[:, :2], cells_list[nb_traj_1:])
+            cells_list_1 = [np.array(x)[:, :2] for x in cells_list[:nb_traj_1]]
+            cells_list_2 = [np.array(x)[:, :2] for x in cells_list[nb_traj_1:]]
         for i in range(nb_traj_1):
             cells_list_1_i = cells_list_1[i]
             for j in range(nb_traj_2):

--- a/traj_dist/pydist/basic_euclidean.py
+++ b/traj_dist/pydist/basic_euclidean.py
@@ -111,7 +111,7 @@ def point_to_trajectory(p, t, mdist_p, t_dist, l_t):
           Point-to-trajectory distance between p and trajectory t
     """
     dpt = min(
-        map(lambda it: point_to_seg(p, t[it], t[it + 1], mdist_p[it], mdist_p[it + 1], t_dist[it]), range(l_t - 1)))
+        [point_to_seg(p, t[it], t[it + 1], mdist_p[it], mdist_p[it + 1], t_dist[it]) for it in range(l_t - 1)])
     return dpt
 
 

--- a/traj_dist/pydist/discret_frechet.py
+++ b/traj_dist/pydist/discret_frechet.py
@@ -1,5 +1,5 @@
 import numpy as np
-from basic_euclidean import eucl_dist
+from .basic_euclidean import eucl_dist
 
 
 def discret_frechet(t0, t1):

--- a/traj_dist/pydist/dtw.py
+++ b/traj_dist/pydist/dtw.py
@@ -1,6 +1,6 @@
 import numpy as np
-from basic_euclidean import eucl_dist
-from basic_spherical import great_circle_distance
+from .basic_euclidean import eucl_dist
+from .basic_spherical import great_circle_distance
 
 
 ######################

--- a/traj_dist/pydist/edr.py
+++ b/traj_dist/pydist/edr.py
@@ -1,5 +1,5 @@
-from basic_euclidean import eucl_dist
-from basic_spherical import great_circle_distance
+from .basic_euclidean import eucl_dist
+from .basic_spherical import great_circle_distance
 
 
 ######################

--- a/traj_dist/pydist/erp.py
+++ b/traj_dist/pydist/erp.py
@@ -1,6 +1,6 @@
 import numpy as np
-from basic_euclidean import eucl_dist, eucl_dist_traj
-from basic_spherical import great_circle_distance
+from .basic_euclidean import eucl_dist, eucl_dist_traj
+from .basic_spherical import great_circle_distance
 
 
 ######################
@@ -28,8 +28,8 @@ def e_erp(t0, t1, g):
     n1 = len(t1)
     C = np.zeros((n0 + 1, n1 + 1))
 
-    gt0_dist = map(lambda x: abs(eucl_dist(g, x)), t0)
-    gt1_dist = map(lambda x: abs(eucl_dist(g, x)), t1)
+    gt0_dist = [abs(eucl_dist(g, x)) for x in t0]
+    gt1_dist = [abs(eucl_dist(g, x)) for x in t1]
     mdist = eucl_dist_traj(t0, t1)
 
     C[1:, 0] = sum(gt0_dist)
@@ -68,8 +68,8 @@ def s_erp(t0, t1, g):
     n1 = len(t1)
     C = np.zeros((n0 + 1, n1 + 1))
 
-    C[1:, 0] = sum(map(lambda x: abs(great_circle_distance(g[0], g[1], x[0], x[1])), t0))
-    C[0, 1:] = sum(map(lambda y: abs(great_circle_distance(g[0], g[1], y[0], y[1])), t1))
+    C[1:, 0] = sum([abs(great_circle_distance(g[0], g[1], x[0], x[1])) for x in t0])
+    C[0, 1:] = sum([abs(great_circle_distance(g[0], g[1], y[0], y[1])) for y in t1])
     for i in np.arange(n0) + 1:
         for j in np.arange(n1) + 1:
             derp0 = C[i - 1, j] + great_circle_distance(t0[i - 1][0], t0[i - 1][1], g[0], g[1])

--- a/traj_dist/pydist/frechet.py
+++ b/traj_dist/pydist/frechet.py
@@ -2,7 +2,7 @@
 # International Journal of Computational Geometry & Applications.
 # Vol 5, Nos 1&2 (1995) 75-91
 
-from basic_euclidean import eucl_dist, point_to_seg, circle_line_intersection, eucl_dist_traj
+from .basic_euclidean import eucl_dist, point_to_seg, circle_line_intersection, eucl_dist_traj
 
 
 def free_line(p, eps, s, dps1, dps2, ds):
@@ -245,8 +245,8 @@ def frechet(P, Q):
     q = len(Q)
 
     mdist = eucl_dist_traj(P, Q)
-    P_dist = map(lambda ip: eucl_dist(P[ip], P[ip + 1]), range(p - 1))
-    Q_dist = map(lambda iq: eucl_dist(Q[iq], Q[iq + 1]), range(q - 1))
+    P_dist = [eucl_dist(P[ip], P[ip + 1]) for ip in range(p - 1)]
+    Q_dist = [eucl_dist(Q[iq], Q[iq + 1]) for iq in range(q - 1)]
 
     cc = compute_critical_values(P, Q, p, q, mdist, P_dist, Q_dist)
     eps = cc[0]

--- a/traj_dist/pydist/hausdorff.py
+++ b/traj_dist/pydist/hausdorff.py
@@ -1,5 +1,5 @@
-from basic_euclidean import point_to_trajectory, eucl_dist_traj, eucl_dist
-from basic_spherical import point_to_path, great_circle_distance, great_circle_distance_traj
+from .basic_euclidean import point_to_trajectory, eucl_dist_traj, eucl_dist
+from .basic_spherical import point_to_path, great_circle_distance, great_circle_distance_traj
 
 
 ######################
@@ -29,7 +29,7 @@ def e_directed_hausdorff(t1, t2, mdist, l_t1, l_t2, t2_dist):
     -------
     dh : float, directed hausdorff from trajectory t1 to trajectory t2
     """
-    dh = max(map(lambda i1: point_to_trajectory(t1[i1], t2, mdist[i1], t2_dist, l_t2), range(l_t1)))
+    dh = max([point_to_trajectory(t1[i1], t2, mdist[i1], t2_dist, l_t2) for i1 in range(l_t1)])
     return dh
 
 
@@ -51,8 +51,8 @@ def e_hausdorff(t1, t2):
     mdist = eucl_dist_traj(t1, t2)
     l_t1 = len(t1)
     l_t2 = len(t2)
-    t1_dist = map(lambda it1: eucl_dist(t1[it1], t1[it1 + 1]), range(l_t1 - 1))
-    t2_dist = map(lambda it2: eucl_dist(t2[it2], t2[it2 + 1]), range(l_t2 - 1))
+    t1_dist = [eucl_dist(t1[it1], t1[it1 + 1]) for it1 in range(l_t1 - 1)]
+    t2_dist = [eucl_dist(t2[it2], t2[it2 + 1]) for it2 in range(l_t2 - 1)]
 
     h = max(e_directed_hausdorff(t1, t2, mdist, l_t1, l_t2, t2_dist),
             e_directed_hausdorff(t2, t1, mdist.T, l_t2, l_t1, t1_dist))
@@ -120,10 +120,8 @@ def s_hausdorff(t0, t1):
 
     mdist = great_circle_distance_traj(lons0, lats0, lons1, lats1, n0, n1)
 
-    t0_dist = map(lambda it0: great_circle_distance(lons0[it0], lats0[it0], lons0[it0 + 1], lats0[it0 + 1]),
-                  range(n0 - 1))
-    t1_dist = map(lambda it1: great_circle_distance(lons1[it1], lats1[it1], lons1[it1 + 1], lats1[it1 + 1]),
-                  range(n1 - 1))
+    t0_dist = [great_circle_distance(lons0[it0], lats0[it0], lons0[it0 + 1], lats0[it0 + 1]) for it0 in range(n0 - 1)]
+    t1_dist = [great_circle_distance(lons1[it1], lats1[it1], lons1[it1 + 1], lats1[it1 + 1]) for it1 in range(n1 - 1)]
 
     h = max(s_directed_hausdorff(lons0, lats0, lons1, lats1, n0, n1, mdist, t0_dist),
             s_directed_hausdorff(lons1, lats1, lons0, lats0, n1, n0, mdist.T, t1_dist))

--- a/traj_dist/pydist/lcss.py
+++ b/traj_dist/pydist/lcss.py
@@ -1,5 +1,5 @@
-from basic_euclidean import eucl_dist
-from basic_spherical import great_circle_distance
+from .basic_euclidean import eucl_dist
+from .basic_spherical import great_circle_distance
 
 
 ######################

--- a/traj_dist/pydist/linecell.py
+++ b/traj_dist/pydist/linecell.py
@@ -1,4 +1,4 @@
-import Geohash.geohash as geoh
+import geohash2.geohash as geoh
 import shapely.geometry as geos
 import numpy as np
 
@@ -58,7 +58,7 @@ def linecell_lons_bigger_step(p1, p2, cell_start, lons_all, lats_all, lons_cente
         cell.append([cell[-1][0], cell[-1][1] + 1])
     if reverse:
         cell.reverse()
-    cells_coord = map(lambda x: [lons_center_all[x[0]], lats_center_all[x[1]]], cell)
+    cells_coord = [[lons_center_all[x[0]], lats_center_all[x[1]]] for x in cell]
     return cell, cells_coord
 
 
@@ -117,7 +117,7 @@ def linecell_lats_bigger_step(p1, p2, cell_start, lons_all, lats_all, lons_cente
         cell.append([cell[-1][0] + 1, cell[-1][1]])
     if reverse:
         cell.reverse()
-    cells_coord = map(lambda x: [lons_center_all[x[0]], lats_center_all[x[1]]], cell)
+    cells_coord = [[lons_center_all[x[0]], lats_center_all[x[1]]] for x in cell]
     return cell, cells_coord
 
 
@@ -132,7 +132,7 @@ def get_extremum(traj):
 
 
 def trajectory_set_grid(traj_set, precision, time=False):
-    extremums = np.array(map(get_extremum, traj_set))
+    extremums = np.array(list(map(get_extremum, traj_set)))
     p_bottom_left = [min(extremums[:, 0]), min(extremums[:, 1])]
     p_top_right = [max(extremums[:, 2]), max(extremums[:, 3])]
     p_ble = geoh.encode(p_bottom_left[1], p_bottom_left[0], precision)
@@ -175,7 +175,7 @@ def trajectory_set_grid(traj_set, precision, time=False):
                         cell_time = []
                     else:
                         cell_time = [cell[0] + [True, [cell_start_time]]]
-                cell_time = cell_time + map(lambda x: x + [False, -1], cell[1:-1])
+                cell_time = cell_time + [x + [False, -1] for x in cell[1:-1]]
             else:
                 if not cells:
                     cell_time = [cell[0] + [True]]
@@ -184,7 +184,7 @@ def trajectory_set_grid(traj_set, precision, time=False):
                         cell_time = []
                     else:
                         cell_time = [cell[0] + [True]]
-                cell_time = cell_time + map(lambda x: x + [False], cell[1:-1])
+                cell_time = cell_time + [x + [False] for x in cell[1:-1]]
 
             cells.extend(cell_time)
             cell_start = cell[-1]

--- a/traj_dist/pydist/segment_distance.py
+++ b/traj_dist/pydist/segment_distance.py
@@ -1,4 +1,4 @@
-from basic_euclidean import eucl_dist
+from .basic_euclidean import eucl_dist
 import math
 import numpy as np
 

--- a/traj_dist/pydist/sowd.py
+++ b/traj_dist/pydist/sowd.py
@@ -1,5 +1,5 @@
 import numpy as np
-import linecell as linec
+from . import linecell as linec
 
 
 def owd_grid_brut(traj_cell_1, traj_cell_2):
@@ -21,7 +21,7 @@ def owd_grid_brut(traj_cell_1, traj_cell_2):
     D = 0
     n = len(traj_cell_1)
     for p1 in traj_cell_1:
-        d = map(lambda x: np.linalg.norm(p1 - x), traj_cell_2)
+        d = [np.linalg.norm(p1 - x) for x in traj_cell_2]
         D += min(d)
     owd = D / n
     return owd
@@ -75,7 +75,7 @@ def owd_grid(traj_cell_1, traj_cell_2):
     n2 = len(traj_cell_2)
 
     p = traj_cell_1[0]
-    p_t2 = map(lambda x: np.linalg.norm(p - x), traj_cell_2)
+    p_t2 = [np.linalg.norm(p - x) for x in traj_cell_2]
     S_old = find_first_min_points(p_t2, n2)
     D = min(p_t2)
     for i in range(1, n1):
@@ -93,13 +93,13 @@ def owd_grid(traj_cell_1, traj_cell_2):
             else:
                 if j == 0:
                     if n_S_old == 1:
-                        ranges = range(0, n2)
+                        ranges = list(range(0, n2))
                     else:
-                        ranges = range(0, S_old[j + 1])
+                        ranges = list(range(0, S_old[j + 1]))
                 elif j == n_S_old - 1:
-                    ranges = range(S_old[j - 1], n2)
+                    ranges = list(range(S_old[j - 1], n2))
                 else:
-                    ranges = range(S_old[j - 1] + 1, S_old[j + 1])
+                    ranges = list(range(S_old[j - 1] + 1, S_old[j + 1]))
                 for igp in ranges:
                     pgp = traj_cell_2[igp]
                     if (p_prec[1] == p[1] and pgp[0] == p[0]) or (p_prec[0] == p[0] and pgp[1] == p[1]) or igp == ig:

--- a/traj_dist/pydist/sspd.py
+++ b/traj_dist/pydist/sspd.py
@@ -1,6 +1,6 @@
 import numpy as np
-from basic_euclidean import eucl_dist, eucl_dist_traj, point_to_trajectory
-from basic_spherical import point_to_path, great_circle_distance, great_circle_distance_traj
+from .basic_euclidean import eucl_dist, eucl_dist_traj, point_to_trajectory
+from .basic_spherical import point_to_path, great_circle_distance, great_circle_distance_traj
 
 
 ######################
@@ -30,7 +30,7 @@ def e_spd(t1, t2, mdist, l_t1, l_t2, t2_dist):
            spd-distance of trajectory t2 from trajectory t1
     """
 
-    spd = sum(map(lambda i1: point_to_trajectory(t1[i1], t2, mdist[i1], t2_dist, l_t2), range(l_t1))) / l_t1
+    spd = sum([point_to_trajectory(t1[i1], t2, mdist[i1], t2_dist, l_t2) for i1 in range(l_t1)]) / l_t1
     return spd
 
 
@@ -54,8 +54,8 @@ def e_sspd(t1, t2):
     mdist = eucl_dist_traj(t1, t2)
     l_t1 = len(t1)
     l_t2 = len(t2)
-    t1_dist = map(lambda it1: eucl_dist(t1[it1], t1[it1 + 1]), range(l_t1 - 1))
-    t2_dist = map(lambda it2: eucl_dist(t2[it2], t2[it2 + 1]), range(l_t2 - 1))
+    t1_dist = [eucl_dist(t1[it1], t1[it1 + 1]) for it1 in range(l_t1 - 1)]
+    t2_dist = [eucl_dist(t2[it2], t2[it2 + 1]) for it2 in range(l_t2 - 1)]
 
     sspd = (e_spd(t1, t2, mdist, l_t1, l_t2, t2_dist) + e_spd(t2, t1, mdist.T, l_t2, l_t1, t1_dist)) / 2
     return sspd
@@ -126,10 +126,8 @@ def s_sspd(t0, t1):
 
     mdist = great_circle_distance_traj(lons0, lats0, lons1, lats1, n0, n1)
 
-    t0_dist = map(lambda it0: great_circle_distance(lons0[it0], lats0[it0], lons0[it0 + 1], lats0[it0 + 1]),
-                  range(n0 - 1))
-    t1_dist = map(lambda it1: great_circle_distance(lons1[it1], lats1[it1], lons1[it1 + 1], lats1[it1 + 1]),
-                  range(n1 - 1))
+    t0_dist = [great_circle_distance(lons0[it0], lats0[it0], lons0[it0 + 1], lats0[it0 + 1]) for it0 in range(n0 - 1)]
+    t1_dist = [great_circle_distance(lons1[it1], lats1[it1], lons1[it1 + 1], lats1[it1 + 1]) for it1 in range(n1 - 1)]
 
     dist = s_spd(lons0, lats0, lons1, lats1, n0, n1, mdist, t0_dist) + s_spd(lons1, lats1, lons0, lats0, n1, n0,
                                                                              mdist.T, t1_dist)

--- a/trajectory_distance.egg-info/PKG-INFO
+++ b/trajectory_distance.egg-info/PKG-INFO
@@ -6,6 +6,5 @@ Home-page: UNKNOWN
 Author: Brendan Guillouet
 Author-email: brendan.guillouet@gmail.com
 License: UNKNOWN
-Description-Content-Type: UNKNOWN
 Description: UNKNOWN
 Platform: UNKNOWN

--- a/trajectory_distance.egg-info/requires.txt
+++ b/trajectory_distance.egg-info/requires.txt
@@ -1,6 +1,6 @@
-numpy>=1.14.0
-Cython>=0.27.3
-Shapely>=1.6.4
-Geohash==1.0
-pandas>=0.20.3
-scipy>=0.19.1
+numpy>=1.16.2
+Cython>=0.29.6
+shapely>=1.6.4.post2
+geohash2==1.1
+pandas>=0.24.2
+scipy>=0.20.3


### PR DESCRIPTION
Given that support for Python 2 will stop on the January 1, 2020. I have updated the code using an [automated Python 2 to 3 code translation tool](https://docs.python.org/3/library/2to3.html) and altered the Geohash library to use [geohash2](https://pypi.org/project/geohash2/) instead.

The code was tested on Python 3.6 with the following dependencies:
* NumPy >= 1.16.2
* Cython >= 0.29.6
* shapely >= 1.6.4.post2
* geohash2 == 1.1
* pandas >= 0.24.2
* scipy >= 0.20.3

A test was made on a trajectory dataset, where the md5 hashes of the dissimilarity matrices from both the old and new traj-dist packages were identical.