### PR TITLE
Update edr.pyx

### DIFF
--- a/traj_dist/cydist/edr.pyx
+++ b/traj_dist/cydist/edr.pyx
@@ -37,6 +37,10 @@ def c_e_edr(np.ndarray[np.float64_t,ndim=2] t0, np.ndarray[np.float64_t,ndim=2] 
 
     # An (m+1) times (n+1) matrix
     C=np.zeros((n0,n1))
+    for i in range(1,n0):
+        C[i][0] = i
+    for j in range(1,n1):
+        C[0][j] = j
 
     for i from 1 <= i < n0:
         for j from 1 <= j < n1:
@@ -49,7 +53,8 @@ def c_e_edr(np.ndarray[np.float64_t,ndim=2] t0, np.ndarray[np.float64_t,ndim=2] 
             else:
                 subcost = 1
             C[i,j] = fmin(fmin(C[i,j-1]+1, C[i-1,j]+1),C[i-1,j-1]+subcost)
-    edr = float(C[n0-1,n1-1])/fmax(n0-1,n1-1)
+#     edr = float(C[n0-1,n1-1])/fmax(n0-1,n1-1)
+    edr = float(C[n0-1,n1-1])
     return edr
 
 
@@ -80,6 +85,10 @@ def c_g_edr(np.ndarray[np.float64_t,ndim=2] t0, np.ndarray[np.float64_t,ndim=2] 
 
     # An (m+1) times (n+1) matrix
     C=np.zeros((n0,n1))
+    for i in range(1,n0):
+        C[i][0] = i
+    for j in range(1,n1):
+        C[0][j] = j
 
     for i from 1 <= i < n0:
         for j from 1 <= j < n1:
@@ -92,5 +101,6 @@ def c_g_edr(np.ndarray[np.float64_t,ndim=2] t0, np.ndarray[np.float64_t,ndim=2] 
             else:
                 subcost = 1
             C[i,j] = fmin(fmin(C[i,j-1]+1, C[i-1,j]+1),C[i-1,j-1]+subcost)
-    edr = float(C[n0-1,n1-1])/fmax(n0-1,n1-1)
+#     edr = float(C[n0-1,n1-1])/fmax(n0-1,n1-1)
+    edr = float(C[n0-1,n1-1])
     return edr


### PR DESCRIPTION
1. According to the original paper, EDR calculate diatances in the manner of dynamic programming, where n and m are the lengths of the compared trajectories and the lengths would be different in different subproblems. So instead of assigning zeros, here should initialize C with lengths of different sub-trajectories at the first row and first column. 
2. The distance did not divided by the longest length in the original paper. And according to my own experiments, divided by the longest length will give bad case when the lengths of two compared trajectories are far more different.

Thx!